### PR TITLE
Sett enhet for mote til behandlende enhet, ikke fra contextholder

### DIFF
--- a/nais.yaml
+++ b/nais.yaml
@@ -67,6 +67,8 @@ fasitResources:
     resourceType: Smtpserver
   - alias: Aktoer_v2
     resourceType: webserviceendpoint
+  - alias: virksomhet:Arbeidsfordeling_v1
+    resourceType: webserviceendpoint
   - alias: virksomhet:Person_V3
     resourceType: webserviceendpoint
   - alias: Sykefravaersoppfoelging_v1
@@ -80,6 +82,8 @@ fasitResources:
   - alias: virksomhet:EgenAnsatt_v1
     resourceType: webserviceendpoint
   - alias: virksomhet:Organisasjon_v4
+    resourceType: webserviceendpoint
+  - alias: virksomhet:OrganisasjonEnhet_v2
     resourceType: webserviceendpoint
   - alias: virksomhet:OrganisasjonRessursEnhet_v1
     resourceType: webserviceendpoint

--- a/pom.xml
+++ b/pom.xml
@@ -42,11 +42,13 @@
 
         <!-- Tjenester  -->
         <aktoer.version>1.0</aktoer.version>
+        <arbeidsfordeling-v1-tjenestespesifikasjon.version>1.1.0</arbeidsfordeling-v1-tjenestespesifikasjon.version>
         <person-v3.version>3.0.2</person-v3.version>
         <organisasjonenhet-v1-tjenestespesifikasjon.version>1.0.3</organisasjonenhet-v1-tjenestespesifikasjon.version>
         <organisasjonRessursEnhet-v1-tjenestespesifikasjon.version>1.0.3</organisasjonRessursEnhet-v1-tjenestespesifikasjon.version>
         <brukerprofil-v3-tjenestespesifikasjon.version>3.0.1</brukerprofil-v3-tjenestespesifikasjon.version>
         <egenAnsatt-v1-tjenestespesifikasjon.version>1.0.1</egenAnsatt-v1-tjenestespesifikasjon.version>
+        <organisasjonenhet-v2-tjenestespesifikasjon.version>2.1.0</organisasjonenhet-v2-tjenestespesifikasjon.version>
         <organisasjonv4-tjenestespesifikasjon.version>1.0.1</organisasjonv4-tjenestespesifikasjon.version>
         <sykefravaersoppfoelgingv1-tjenestespesifikasjon.version>1.0.22</sykefravaersoppfoelgingv1-tjenestespesifikasjon.version>
         <dkif-tjenestespesifikasjon.version>1.2</dkif-tjenestespesifikasjon.version>
@@ -59,6 +61,11 @@
             <groupId>no.nav.syfo.tjenester</groupId>
             <artifactId>aktoer-v2</artifactId>
             <version>${aktoer.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.sbl.dialogarena</groupId>
+            <artifactId>arbeidsfordeling-v1-tjenestespesifikasjon</artifactId>
+            <version>${arbeidsfordeling-v1-tjenestespesifikasjon.version}</version>
         </dependency>
         <dependency>
             <groupId>no.nav.sbl.dialogarena</groupId>
@@ -89,6 +96,11 @@
             <groupId>no.nav.sbl.dialogarena</groupId>
             <artifactId>organisasjonv4-tjenestespesifikasjon</artifactId>
             <version>${organisasjonv4-tjenestespesifikasjon.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.sbl.dialogarena</groupId>
+            <artifactId>organisasjonenhet-v2-tjenestespesifikasjon</artifactId>
+            <version>${organisasjonenhet-v2-tjenestespesifikasjon.version}</version>
         </dependency>
         <dependency>
             <groupId>no.nav.syfo.tjenester</groupId>

--- a/src/main/java/no/nav/syfo/api/ressurser/MoterRessurs.java
+++ b/src/main/java/no/nav/syfo/api/ressurser/MoterRessurs.java
@@ -45,6 +45,7 @@ public class MoterRessurs {
     private OIDCRequestContextHolder contextHolder;
     private Metrikk metrikk;
     private AktoerService aktoerService;
+    private EnhetService enhetService;
     private MoteService moteService;
     private TidOgStedDAO tidOgStedDAO;
     private HendelseService hendelseService;
@@ -62,6 +63,7 @@ public class MoterRessurs {
             OIDCRequestContextHolder contextHolder,
             Metrikk metrikk,
             AktoerService aktoerService,
+            EnhetService enhetService,
             MoteService moteService,
             TidOgStedDAO tidOgStedDAO,
             HendelseService hendelseService,
@@ -77,6 +79,7 @@ public class MoterRessurs {
         this.contextHolder = contextHolder;
         this.metrikk = metrikk;
         this.aktoerService = aktoerService;
+        this.enhetService = enhetService;
         this.moteService = moteService;
         this.tidOgStedDAO = tidOgStedDAO;
         this.hendelseService = hendelseService;
@@ -186,6 +189,7 @@ public class MoterRessurs {
             NaermesteLeder naermesteLeder = sykefravaersoppfoelgingService.hentNaermesteLederSomBruker(aktorId, nyttMoteRequest.orgnummer);
             nyttMoteRequest.navn(naermesteLeder.navn);
             nyttMoteRequest.epost(naermesteLeder.epost);
+            nyttMoteRequest.navEnhet(enhetService.finnArbeidstakersBehandlendeEnhet(nyttMoteRequest.fnr));
 
             Mote nyttMote = map(nyttMoteRequest, opprett2Mote);
             String innloggetIdent = getSubjectIntern(contextHolder);

--- a/src/main/java/no/nav/syfo/config/CacheConfig.java
+++ b/src/main/java/no/nav/syfo/config/CacheConfig.java
@@ -21,6 +21,8 @@ public class CacheConfig {
     public static final String CACHENAME_EREG_NAVN = "eregnavn";
     public static final String CACHENAME_LDAP_VEILEDER = "ldapveileder";
     public static final String CACHENAME_NORG_ENHETER = "norgenheter";
+    public static final String CACHENAME_ORGN_KONTORGEOGRAFISK = "orgnkontorgeografisk";
+    public static final String CACHENAME_PERSON_GEOGRAFISK = "persongeografisk";
     public static final String CACHENAME_PERSON_PERSON = "person";
     public static final String CACHENAME_TPS_BRUKER = "tpsbruker";
     public static final String CACHENAME_TPS_NAVN = "tpsnavn";
@@ -38,6 +40,8 @@ public class CacheConfig {
                 new ConcurrentMapCache(CACHENAME_EREG_NAVN),
                 new ConcurrentMapCache(CACHENAME_LDAP_VEILEDER),
                 new ConcurrentMapCache(CACHENAME_NORG_ENHETER),
+                new ConcurrentMapCache(CACHENAME_ORGN_KONTORGEOGRAFISK),
+                new ConcurrentMapCache(CACHENAME_PERSON_GEOGRAFISK),
                 new ConcurrentMapCache(CACHENAME_PERSON_PERSON),
                 new ConcurrentMapCache(CACHENAME_TPS_BRUKER),
                 new ConcurrentMapCache(CACHENAME_TPS_NAVN)

--- a/src/main/java/no/nav/syfo/config/consumer/ArbeidsfordelingConfig.java
+++ b/src/main/java/no/nav/syfo/config/consumer/ArbeidsfordelingConfig.java
@@ -1,0 +1,27 @@
+package no.nav.syfo.config.consumer;
+
+import no.nav.syfo.service.ws.*;
+import no.nav.tjeneste.virksomhet.arbeidsfordeling.v1.ArbeidsfordelingV1;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.*;
+
+import java.util.Collections;
+
+@Configuration
+public class ArbeidsfordelingConfig {
+
+    public static final String MOCK_KEY = "arbeidsfordeling.withmock";
+    @Value("${virksomhet.arbeidsfordeling.v1.endpointurl}")
+    private String serviceUrl;
+
+    @SuppressWarnings("unchecked")
+    @Bean
+    @ConditionalOnProperty(value = MOCK_KEY, havingValue = "false", matchIfMissing = true)
+    @Primary
+    public ArbeidsfordelingV1 arbeidsfordelingV1() {
+        ArbeidsfordelingV1 port = new WsClient<ArbeidsfordelingV1>().createPort(serviceUrl, ArbeidsfordelingV1.class, Collections.singletonList(new LogErrorHandler()));
+        STSClientConfig.configureRequestSamlToken(port);
+        return port;
+    }
+}

--- a/src/main/java/no/nav/syfo/config/consumer/OrganisasjonEnhetConfig.java
+++ b/src/main/java/no/nav/syfo/config/consumer/OrganisasjonEnhetConfig.java
@@ -1,0 +1,27 @@
+package no.nav.syfo.config.consumer;
+
+import no.nav.syfo.service.ws.*;
+import no.nav.tjeneste.virksomhet.organisasjonenhet.v2.OrganisasjonEnhetV2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.*;
+
+import static java.util.Collections.singletonList;
+
+@Configuration
+public class OrganisasjonEnhetConfig {
+
+    public static final String MOCK_KEY = "organisasjonenhet.withmock";
+    @Value("${virksomhet.organisasjonEnhet.v2.endpointurl}")
+    private String serviceUrl;
+
+    @SuppressWarnings("unchecked")
+    @Bean
+    @ConditionalOnProperty(value = MOCK_KEY, havingValue = "false", matchIfMissing = true)
+    @Primary
+    public OrganisasjonEnhetV2 organisasjonEnhetV2() {
+        OrganisasjonEnhetV2 port = new WsClient<OrganisasjonEnhetV2>().createPort(serviceUrl, OrganisasjonEnhetV2.class, singletonList(new LogErrorHandler()));
+        STSClientConfig.configureRequestSamlToken(port);
+        return port;
+    }
+}

--- a/src/main/java/no/nav/syfo/config/mocks/ArbeidsfordelingMock.java
+++ b/src/main/java/no/nav/syfo/config/mocks/ArbeidsfordelingMock.java
@@ -1,0 +1,58 @@
+package no.nav.syfo.config.mocks;
+
+import no.nav.tjeneste.virksomhet.arbeidsfordeling.v1.ArbeidsfordelingV1;
+import no.nav.tjeneste.virksomhet.arbeidsfordeling.v1.informasjon.WSEnhetsstatus;
+import no.nav.tjeneste.virksomhet.arbeidsfordeling.v1.informasjon.WSOrganisasjonsenhet;
+import no.nav.tjeneste.virksomhet.arbeidsfordeling.v1.meldinger.*;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import static java.util.Arrays.asList;
+import static no.nav.syfo.config.consumer.ArbeidsfordelingConfig.MOCK_KEY;
+
+@Service
+@ConditionalOnProperty(value = MOCK_KEY, havingValue = "true")
+public class ArbeidsfordelingMock implements ArbeidsfordelingV1 {
+
+    @Override
+    public void ping() {
+    }
+
+    @Override
+    public WSFinnAlleBehandlendeEnheterListeResponse
+    finnAlleBehandlendeEnheterListe(WSFinnAlleBehandlendeEnheterListeRequest request) {
+        return new WSFinnAlleBehandlendeEnheterListeResponse().withBehandlendeEnhetListe(asList(
+                new WSOrganisasjonsenhet()
+                        .withEnhetId("0330")
+                        .withEnhetNavn("NAV Bjerke")
+                        .withStatus(
+                                WSEnhetsstatus.fromValue("AKTIV")
+                        ),
+                new WSOrganisasjonsenhet()
+                        .withEnhetNavn("0314")
+                        .withEnhetNavn("NAV Sagene")
+                        .withStatus(
+                                WSEnhetsstatus.fromValue("AKTIV")
+                        )
+        ));
+    }
+
+    @Override
+    public WSFinnBehandlendeEnhetListeResponse
+    finnBehandlendeEnhetListe(WSFinnBehandlendeEnhetListeRequest request) {
+        return new WSFinnBehandlendeEnhetListeResponse().withBehandlendeEnhetListe(asList(
+                new WSOrganisasjonsenhet()
+                        .withEnhetId("0330")
+                        .withEnhetNavn("NAV Bjerke")
+                        .withStatus(
+                                WSEnhetsstatus.fromValue("AKTIV")
+                        ),
+                new WSOrganisasjonsenhet()
+                        .withEnhetNavn("0314")
+                        .withEnhetNavn("NAV Sagene")
+                        .withStatus(
+                                WSEnhetsstatus.fromValue("AKTIV")
+                        )
+        ));
+    }
+}

--- a/src/main/java/no/nav/syfo/config/mocks/OrganisasjonEnhetMock.java
+++ b/src/main/java/no/nav/syfo/config/mocks/OrganisasjonEnhetMock.java
@@ -1,0 +1,45 @@
+package no.nav.syfo.config.mocks;
+
+import no.nav.tjeneste.virksomhet.organisasjonenhet.v2.OrganisasjonEnhetV2;
+import no.nav.tjeneste.virksomhet.organisasjonenhet.v2.informasjon.WSEnhetsstatus;
+import no.nav.tjeneste.virksomhet.organisasjonenhet.v2.informasjon.WSOrganisasjonsenhet;
+import no.nav.tjeneste.virksomhet.organisasjonenhet.v2.meldinger.*;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import static no.nav.syfo.config.consumer.OrganisasjonEnhetConfig.MOCK_KEY;
+
+@Service
+@ConditionalOnProperty(value = MOCK_KEY, havingValue = "true")
+public class OrganisasjonEnhetMock implements OrganisasjonEnhetV2 {
+
+    @Override
+    public void ping() {}
+
+    @Override
+    public WSFinnNAVKontorResponse finnNAVKontor(WSFinnNAVKontorRequest wsFinnNAVKontorRequest) {
+        return new WSFinnNAVKontorResponse()
+                .withNAVKontor(new WSOrganisasjonsenhet()
+                        .withEnhetId("0330")
+                        .withEnhetNavn("Bjerke")
+                        .withStatus(WSEnhetsstatus.AKTIV)
+                );
+    }
+
+    @Override
+    public WSHentFullstendigEnhetListeResponse hentFullstendigEnhetListe(WSHentFullstendigEnhetListeRequest wsHentFullstendigEnhetListeRequest) {
+        return null;
+    }
+
+    @Override
+    public WSHentEnhetBolkResponse hentEnhetBolk(WSHentEnhetBolkRequest wsHentEnhetBolkRequest) {
+        return null;
+    }
+
+    @Override
+    public WSHentOverordnetEnhetListeResponse hentOverordnetEnhetListe(WSHentOverordnetEnhetListeRequest wsHentOverordnetEnhetListeRequest) {
+        return null;
+    }
+
+
+}

--- a/src/main/java/no/nav/syfo/service/ArbeidsfordelingService.java
+++ b/src/main/java/no/nav/syfo/service/ArbeidsfordelingService.java
@@ -1,0 +1,49 @@
+package no.nav.syfo.service;
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.syfo.domain.model.Enhet;
+import no.nav.tjeneste.virksomhet.arbeidsfordeling.v1.ArbeidsfordelingV1;
+import no.nav.tjeneste.virksomhet.arbeidsfordeling.v1.FinnBehandlendeEnhetListeUgyldigInput;
+import no.nav.tjeneste.virksomhet.arbeidsfordeling.v1.informasjon.*;
+import no.nav.tjeneste.virksomhet.arbeidsfordeling.v1.meldinger.WSFinnBehandlendeEnhetListeRequest;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+import static no.nav.tjeneste.virksomhet.arbeidsfordeling.v1.informasjon.WSEnhetsstatus.AKTIV;
+
+@Component
+@Slf4j
+public class ArbeidsfordelingService {
+
+    private final ArbeidsfordelingV1 arbeidsfordelingV1;
+
+    public ArbeidsfordelingService(ArbeidsfordelingV1 arbeidsfordelingV1) {
+        this.arbeidsfordelingV1 = arbeidsfordelingV1;
+    }
+
+    public Enhet finnAktivBehandlendeEnhet(String geografiskTilknytning) {
+        try {
+            return arbeidsfordelingV1.finnBehandlendeEnhetListe(
+                    new WSFinnBehandlendeEnhetListeRequest()
+                            .withArbeidsfordelingKriterier(new WSArbeidsfordelingKriterier()
+                                    .withGeografiskTilknytning(new WSGeografi().withValue(geografiskTilknytning))
+                                    .withTema(new WSTema().withValue("OPP")))
+            ).getBehandlendeEnhetListe()
+                    .stream()
+                    .filter(wsOrganisasjonsenhet -> AKTIV.equals(wsOrganisasjonsenhet.getStatus()))
+                    .map(wsOrganisasjonsenhet -> new Enhet().enhetId(wsOrganisasjonsenhet.getEnhetId()).navn(wsOrganisasjonsenhet.getEnhetNavn()))
+                    .findFirst()
+                    .orElse(new Enhet()
+                            .enhetId(geografiskTilknytning)
+                            .navn(geografiskTilknytning)
+                    );
+        } catch (FinnBehandlendeEnhetListeUgyldigInput e) {
+            log.error("Feil ved henting av brukers forvaltningsenhet med geografiskTilknytning: " + geografiskTilknytning);
+            throw new RuntimeException("Feil ved henting av brukers forvaltningsenhet", e);
+        } catch (RuntimeException e) {
+            log.error("Feil ved henting av behandlende enhet for geografiskTilknytning: " + geografiskTilknytning);
+            throw e;
+        }
+    }
+
+}

--- a/src/main/java/no/nav/syfo/service/EnhetService.java
+++ b/src/main/java/no/nav/syfo/service/EnhetService.java
@@ -1,0 +1,42 @@
+package no.nav.syfo.service;
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.syfo.domain.model.Enhet;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class EnhetService {
+
+    private final ArbeidsfordelingService arbeidsfordelingService;
+
+    private final EgenAnsattService egenAnsattService;
+
+    private final OrganisasjonEnhetService organisasjonEnhetService;
+
+    private final PersonService personService;
+
+    @Autowired
+    public EnhetService(
+            ArbeidsfordelingService arbeidsfordelingService,
+            EgenAnsattService egenAnsattService,
+            OrganisasjonEnhetService organisasjonEnhetService,
+            PersonService personService
+    ) {
+        this.arbeidsfordelingService = arbeidsfordelingService;
+        this.egenAnsattService = egenAnsattService;
+        this.organisasjonEnhetService = organisasjonEnhetService;
+        this.personService = personService;
+    }
+
+    public String finnArbeidstakersBehandlendeEnhet(String arbeidstakerFnr) {
+        String geografiskTilknytning = personService.hentGeografiskTilknytning(arbeidstakerFnr);
+        Enhet enhet = arbeidsfordelingService.finnAktivBehandlendeEnhet(geografiskTilknytning);
+        if (egenAnsattService.erEgenAnsatt(arbeidstakerFnr)) {
+            Enhet overordnetEnhet = organisasjonEnhetService.finnSetteKontor(enhet.enhetId()).orElse(enhet);
+            return overordnetEnhet.enhetId();
+        }
+        return enhet.enhetId();
+    }
+}

--- a/src/main/java/no/nav/syfo/service/OrganisasjonEnhetService.java
+++ b/src/main/java/no/nav/syfo/service/OrganisasjonEnhetService.java
@@ -1,0 +1,42 @@
+package no.nav.syfo.service;
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.syfo.domain.model.Enhet;
+import no.nav.tjeneste.virksomhet.organisasjonenhet.v2.HentOverordnetEnhetListeEnhetIkkeFunnet;
+import no.nav.tjeneste.virksomhet.organisasjonenhet.v2.OrganisasjonEnhetV2;
+import no.nav.tjeneste.virksomhet.organisasjonenhet.v2.informasjon.WSEnhetRelasjonstyper;
+import no.nav.tjeneste.virksomhet.organisasjonenhet.v2.meldinger.WSHentOverordnetEnhetListeRequest;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+import static no.nav.tjeneste.virksomhet.organisasjonenhet.v2.informasjon.WSEnhetsstatus.AKTIV;
+
+@Component
+@Slf4j
+public class OrganisasjonEnhetService {
+
+    private final OrganisasjonEnhetV2 organisasjonEnhetV2;
+
+    @Inject
+    public OrganisasjonEnhetService(OrganisasjonEnhetV2 organisasjonEnhetV2) {
+        this.organisasjonEnhetV2 = organisasjonEnhetV2;
+    }
+
+    public Optional<Enhet> finnSetteKontor(String enhet) {
+        try {
+            return organisasjonEnhetV2.hentOverordnetEnhetListe(new WSHentOverordnetEnhetListeRequest()
+                    .withEnhetId(enhet).withEnhetRelasjonstype(new WSEnhetRelasjonstyper().withValue("HABILITET")))
+                    .getOverordnetEnhetListe()
+                    .stream()
+                    .filter(wsOrganisasjonsenhet -> AKTIV.equals(wsOrganisasjonsenhet.getStatus()))
+                    .map(wsOrganisasjonsenhet -> new Enhet().enhetId(wsOrganisasjonsenhet.getEnhetId()).navn(wsOrganisasjonsenhet.getEnhetNavn()))
+                    .findFirst();
+        } catch (HentOverordnetEnhetListeEnhetIkkeFunnet e) {
+            log.error("Fant ingen overordnet enhet for enhet {}", enhet);
+            throw new RuntimeException();
+        }
+    }
+
+}

--- a/src/test/java/no/nav/syfo/api/ressurser/MoterRessursTilgangTest.java
+++ b/src/test/java/no/nav/syfo/api/ressurser/MoterRessursTilgangTest.java
@@ -52,6 +52,8 @@ public class MoterRessursTilgangTest {
     @Mock
     private MoteService moteService;
     @Mock
+    private EnhetService enhetService;
+    @Mock
     private Metrikk metrikk;
     @Mock
     private TidOgStedDAO tidOgStedDAO;
@@ -83,6 +85,7 @@ public class MoterRessursTilgangTest {
         when(aktoerService.hentAktoerIdForIdent(ARBEIDSTAKER_FNR)).thenReturn(ARBEIDSTAKER_AKTORID);
         when(aktoerService.hentFnrForAktoer(AKTOER_ID_2)).thenReturn(FNR_2);
         when(moteService.findMoterByBrukerNavEnhet(NAVENHET)).thenReturn(MoteList);
+        when(enhetService.finnArbeidstakersBehandlendeEnhet(any())).thenReturn(NAVENHET);
     }
 
     private List<Mote> MoteList = asList(
@@ -298,6 +301,7 @@ public class MoterRessursTilgangTest {
         moterRessurs.opprett(nyttMoteRequest);
 
         verify(brukerprofilService).hentBruker(ARBEIDSTAKER_FNR);
+        verify(enhetService).finnArbeidstakersBehandlendeEnhet(ARBEIDSTAKER_FNR);
     }
 
     @Test(expected = ForbiddenException.class)

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -48,19 +48,21 @@ virksomhet:
   diskresjonskode.v1.endpointurl: "diskresjonskode.url"
   egenansatt.v1.endpointurl: "egenansattv1.url"
   organisasjon.v4.endpointurl: "organisasjonv4.url"
-  organisasjonenhet.v2.endpointurl: "organisasjonEnhetv2.url"
+  organisasjonEnhet.v2.endpointurl: "organisasjonEnhetv2.url"
   organisasjonressursenhet.v1.endpointurl: "organisasjonRessursEnhetv1.url"
   person.v3.endpointurl: "personv3.url"
 
 fasit.environment.name: 'local'
 
 aktoer.withmock: true
+arbeidsfordeling.withmock: true
 arena.withmock: true
 brukerprofil.withmock: true
 dkif.withmock: true
 egenansatt.withmock: true
 ereg.withmock: true
 norg.withmock: true
+organisasjonenhet.withmock: true
 person.withmock: true
 sykefravaersoppfoelging.syfoservice.withmock: true
 


### PR DESCRIPTION
Gir konsitens i mellom hendelser som vises i syfooversikt for bruker(oppfolgingsplan, moteplanleggersvar og motebehovsvar).
I dag er plan og motebehov koblet til behandlende enhet, men møteplanelagger er ikke det. Denne endringen sørger for at alle tre er knyttet til behandlende enhet.