### PR TITLE
Add AD veileder token to syfo-tilgangkontroll check

### DIFF
--- a/src/main/java/no/nav/syfo/util/OIDCUtil.java
+++ b/src/main/java/no/nav/syfo/util/OIDCUtil.java
@@ -1,6 +1,7 @@
 package no.nav.syfo.util;
 
 import com.nimbusds.jwt.JWTClaimsSet;
+import no.nav.security.oidc.OIDCConstants;
 import no.nav.security.oidc.context.*;
 import no.nav.syfo.oidc.OIDCClaim;
 import no.nav.syfo.oidc.OIDCIssuer;
@@ -63,5 +64,12 @@ public class OIDCUtil {
         } catch (ParseException e) {
             throw new RuntimeException("Klarte ikke hente veileder-ident ut av OIDC-token (Azure)");
         }
+    }
+
+    public static String tokenFraOIDC(OIDCRequestContextHolder contextHolder, String issuer) {
+        OIDCValidationContext context = (OIDCValidationContext) contextHolder
+                .getRequestAttribute(OIDCConstants.OIDC_VALIDATION_CONTEXT);
+
+        return  context.getToken(issuer).getIdToken();
     }
 }


### PR DESCRIPTION
Må testes skikkelig i prod. Dette skal fikse problemene med tilgangssjekk for nye syfomoteoversikt, og samtidig skal applikasjonen fungere for den gamle versjonen --> moteoversiktfssfront.

Det er kjente "feil" i preprod med oppslag i areg for noen av testbrukerne. 