### PR TITLE
Add trengerBehandling, to replace veilederoppgave

### DIFF
--- a/src/main/java/no/nav/syfo/api/domain/RSMote.java
+++ b/src/main/java/no/nav/syfo/api/domain/RSMote.java
@@ -24,5 +24,6 @@ public class RSMote {
     public RSTidOgSted bekreftetAlternativ;
     public List<RSTidOgSted> alternativer = new ArrayList<>();
     public LocalDateTime sistEndret;
+    public boolean trengerBehandling;
 }
 

--- a/src/main/java/no/nav/syfo/api/ressurser/azuread/MoterInternController.java
+++ b/src/main/java/no/nav/syfo/api/ressurser/azuread/MoterInternController.java
@@ -162,7 +162,19 @@ public class MoterInternController {
 
         metrikk.tellEndepunktKall("hent_moter");
 
-        return mapListe(moter, mote2rs).stream().map(rsMote -> rsMote.sistEndret(hendelseService.sistEndretMoteStatus(rsMote.id).orElse(rsMote.opprettetTidspunkt))).collect(toList());
+        return mapListe(moter, mote2rs)
+                .stream()
+                .map(rsMote -> rsMote
+                        .sistEndret(hendelseService.sistEndretMoteStatus(rsMote.id)
+                                .orElse(rsMote.opprettetTidspunkt))
+                        .trengerBehandling(trengerBehandling(rsMote)))
+                .collect(toList());
+    }
+
+    private boolean trengerBehandling(RSMote rsMote) {
+        return moteService.harAlleSvartPaSisteForesporselRs(rsMote, AZURE)
+                && !"bekreftet".equalsIgnoreCase(rsMote.status)
+                && !"avbrutt".equalsIgnoreCase(rsMote.status);
     }
 
     private List<Mote> populerMedTpsData(List<Mote> moter) {


### PR DESCRIPTION
Sjekker om alle har svart på den siste forespørselen, og om planen ikke er bekreftet enda.
Denne skal bli true i de samme situasjonene hvor man tidligere har hatt en aktiv veilederoppgave.

Hvis alle deltakere som ikke er reservert har svart og svaret kom etter at siste alternativ ble oprettet, trenger møtet behandling, og vi skal vise prikk.
Denne skal bli false hvis man mangler svar, hvis veilederen legger til nye alternativ, bekrefter, eller avbryter møtet.