### PR TITLE
Handle Veileder with no name attribute in LDAP

### DIFF
--- a/src/main/java/no/nav/syfo/config/CacheConfig.java
+++ b/src/main/java/no/nav/syfo/config/CacheConfig.java
@@ -17,7 +17,7 @@ public class CacheConfig {
     public static final String CACHENAME_BEHANDLENDEENHET_FNR = "behandlendeenhetfnr";
     public static final String CACHENAME_DKIF_IDENT = "dkifident";
     public static final String CACHENAME_EREG_VIRKSOMHETSNAVN = "virksomhetsnavn";
-    public static final String CACHENAME_LDAP_VEILEDER = "ldapveileder";
+    public static final String CACHENAME_LDAP_VEILEDER_NAVN = "ldapveiledernavn";
     public static final String CACHENAME_AXSYS_ENHETER = "axsysenheter";
     public static final String CACHENAME_NARMESTELEDER_ANSATTE = "ansatte";
     public static final String CACHENAME_NARMESTELEDER_LEDER = "leder";
@@ -35,7 +35,7 @@ public class CacheConfig {
                 new ConcurrentMapCache(CACHENAME_BEHANDLENDEENHET_FNR),
                 new ConcurrentMapCache(CACHENAME_DKIF_IDENT),
                 new ConcurrentMapCache(CACHENAME_EREG_VIRKSOMHETSNAVN),
-                new ConcurrentMapCache(CACHENAME_LDAP_VEILEDER),
+                new ConcurrentMapCache(CACHENAME_LDAP_VEILEDER_NAVN),
                 new ConcurrentMapCache(CACHENAME_NARMESTELEDER_ANSATTE),
                 new ConcurrentMapCache(CACHENAME_NARMESTELEDER_LEDER),
                 new ConcurrentMapCache(CACHENAME_NORG_ENHETER),

--- a/src/main/java/no/nav/syfo/service/VeilederService.java
+++ b/src/main/java/no/nav/syfo/service/VeilederService.java
@@ -1,15 +1,14 @@
 package no.nav.syfo.service;
 
-
-import no.nav.syfo.domain.model.Veileder;
+import no.nav.syfo.service.ldap.*;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import javax.inject.Inject;
-import java.util.Map;
+import java.util.*;
 
 import static java.util.Arrays.asList;
-import static no.nav.syfo.config.CacheConfig.CACHENAME_LDAP_VEILEDER;
+import static no.nav.syfo.config.CacheConfig.CACHENAME_LDAP_VEILEDER_NAVN;
 
 @Service
 public class VeilederService {
@@ -21,20 +20,17 @@ public class VeilederService {
         this.ldapService = ldapService;
     }
 
-    private String hentVeilederEpost(String veilederUid) {
-        return ldapService.hentVeilederAttributter(veilederUid, asList("mail")).get("mail").toString();
-    }
-
-    private String hentVeilederNavn(String veilederUid) {
+    @Cacheable(value = CACHENAME_LDAP_VEILEDER_NAVN, key = "#veilederUid", condition = "#veilederUid != null")
+    public String hentNavn(String veilederUid) {
         Map map = ldapService.hentVeilederAttributter(veilederUid, asList("givenname", "sn"));
         return map.get("givenname").toString() + " " + map.get("sn").toString();
     }
 
-    @Cacheable(value = CACHENAME_LDAP_VEILEDER, key = "#veilederUid", condition = "#veilederUid != null")
-    public Veileder hentVeileder(String veilederUid) {
-        return new Veileder()
-                .userId(veilederUid)
-                .navn(hentVeilederNavn(veilederUid))
-                .epost(hentVeilederEpost(veilederUid));
+    public Optional<String> hentVeilederNavn(String veilederUid) {
+        try {
+            return Optional.of(hentNavn(veilederUid));
+        } catch (LdapNoAttributesFoundException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/src/main/java/no/nav/syfo/service/ldap/LdapNoAttributesFoundException.java
+++ b/src/main/java/no/nav/syfo/service/ldap/LdapNoAttributesFoundException.java
@@ -1,0 +1,10 @@
+package no.nav.syfo.service.ldap;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+public class LdapNoAttributesFoundException extends WebApplicationException {
+    public LdapNoAttributesFoundException(String message) {
+        super(message, null, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/no/nav/syfo/service/ldap/LdapService.java
+++ b/src/main/java/no/nav/syfo/service/ldap/LdapService.java
@@ -1,5 +1,6 @@
-package no.nav.syfo.service;
+package no.nav.syfo.service.ldap;
 
+import org.slf4j.*;
 import org.springframework.beans.factory.annotation.*;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,8 @@ import static java.util.Optional.ofNullable;
 @SuppressWarnings({"squid:S1149"})
 @Service
 public class LdapService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LdapService.class);
 
     private static Hashtable<String, String> env = new Hashtable<>();
     @Value("${ldap.basedn}")
@@ -45,7 +48,9 @@ public class LdapService {
                 Attributes ldapAttributes = result.next().getAttributes();
                 populateAttributtMap(attributter, map, ldapAttributes);
             } else {
-                throw new RuntimeException("Fant ingen attributter i resultat fra ldap for veileder " + veilederUid);
+                String message = "Fant ingen attributter i resultat fra ldap for veileder " + veilederUid;
+                LOG.warn(message);
+                throw new LdapNoAttributesFoundException(message);
             }
         } catch (NamingException e) {
             throw new RuntimeException(e);

--- a/src/main/java/no/nav/syfo/service/varselinnhold/ArbeidsgiverVarselService.java
+++ b/src/main/java/no/nav/syfo/service/varselinnhold/ArbeidsgiverVarselService.java
@@ -114,7 +114,7 @@ public class ArbeidsgiverVarselService {
     }
 
     private String veiledernavn(String innloggetIdent) {
-        return veilederService.hentVeileder(innloggetIdent).navn;
+        return veilederService.hentVeilederNavn(innloggetIdent).orElse("NAV");
     }
 
     private String sted(TidOgSted valgtTidOgSted) {

--- a/src/main/kotlin/no/nav/syfo/controller/internad/veileder/VeilederAzureRessurs.kt
+++ b/src/main/kotlin/no/nav/syfo/controller/internad/veileder/VeilederAzureRessurs.kt
@@ -28,7 +28,7 @@ class VeilederAzureRessurs @Inject constructor(
     @GetMapping(value = ["/{ident}"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun hentIdent(@PathVariable("ident") ident: String): RSVeilederInfo {
         return RSVeilederInfo(
-                navn = veilederService.hentVeileder(ident).navn,
+                navn = veilederService.hentVeilederNavn(ident).orElse("Fant ikke navn"),
                 ident = ident
         )
     }

--- a/src/test/java/no/nav/syfo/api/ressurser/azuread/MoterInternControllerTest.java
+++ b/src/test/java/no/nav/syfo/api/ressurser/azuread/MoterInternControllerTest.java
@@ -31,7 +31,7 @@ import org.springframework.web.client.RestTemplate;
 import javax.inject.Inject;
 import javax.ws.rs.ForbiddenException;
 import java.text.ParseException;
-import java.util.List;
+import java.util.*;
 
 import static java.time.LocalDateTime.now;
 import static java.util.Arrays.asList;
@@ -354,7 +354,7 @@ public class MoterInternControllerTest extends AbstractRessursTilgangTest {
         when(tidOgStedDAO.create(any())).thenReturn(new TidOgSted());
         when(motedeltakerDAO.create(any(PMotedeltakerAktorId.class))).thenReturn(new MotedeltakerAktorId());
         when(motedeltakerDAO.create(any(PMotedeltakerArbeidsgiver.class))).thenReturn(new MotedeltakerArbeidsgiver());
-        when(veilederService.hentVeileder(any())).thenReturn(new Veileder());
+        when(veilederService.hentVeilederNavn(any())).thenReturn(Optional.of(VEILEDER_NAVN));
 
         moterController.opprett(nyttMoteRequest);
 

--- a/src/test/java/no/nav/syfo/api/ressurser/azuread/VeilederAzureRessursTest.java
+++ b/src/test/java/no/nav/syfo/api/ressurser/azuread/VeilederAzureRessursTest.java
@@ -5,7 +5,6 @@ import no.nav.syfo.api.ressurser.AbstractRessursTilgangTest;
 import no.nav.syfo.axsys.AxsysConsumer;
 import no.nav.syfo.axsys.AxsysEnhet;
 import no.nav.syfo.controller.internad.veileder.*;
-import no.nav.syfo.domain.model.Veileder;
 import no.nav.syfo.service.VeilederService;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,6 +16,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import javax.inject.Inject;
 import java.text.ParseException;
+import java.util.Optional;
 
 import static java.util.Arrays.asList;
 import static no.nav.syfo.testhelper.OidcTestHelper.loggInnVeilederAzure;
@@ -52,8 +52,7 @@ public class VeilederAzureRessursTest extends AbstractRessursTilgangTest {
         } catch (ParseException e) {
             e.printStackTrace();
         }
-        Veileder veileder = new Veileder().navn(VEILEDER_NAVN);
-        when(veilederService.hentVeileder(VEILEDER_ID)).thenReturn(veileder);
+        when(veilederService.hentVeilederNavn(VEILEDER_ID)).thenReturn(Optional.of(VEILEDER_NAVN));
     }
 
     @Test


### PR DESCRIPTION
Veileders can be removed from LDAP due to change of employment which results in no attributes found when performing a request to get the name of a Veileder From LDAP. Handling of this case is there added with a custom exception and a wrapping of name in an Optional that is empty if no attributes for name is found.