### PR TITLE
Set opprettetDato to now if missing in NarmesteLederUtil

### DIFF
--- a/src/main/kotlin/no/nav/syfo/util/NarmesteLederUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/NarmesteLederUtil.kt
@@ -7,7 +7,7 @@ import java.time.LocalDate
 
 fun narmesteLederForMeeting(narmesteLedere: List<NarmesteLederRelasjon>, mote: Mote): NarmesteLederRelasjon? {
     val wantedOrgnummer = mote.arbeidsgiver().orgnummer
-    val moteOpprettetDate = mote.opprettetTidspunkt.toLocalDate()
+    val moteOpprettetDate = mote.opprettetTidspunkt?.toLocalDate() ?: LocalDate.now()
 
     val narmesteLeder = narmesteLedere.filter {
         isLeaderForOrgnummerAndAktivFomBeforeDate(it, wantedOrgnummer, moteOpprettetDate)


### PR DESCRIPTION
Når veileder oppretter et møte, blir ikke opprettetDato med, den blir satt i databasen, og så får vi tilgang til den neste gang vi skal gjøre noe med møtet. Nå er antakelsen at hvis vi ikke har opprettetDato, er det et nytt møte, og det er greit å bruke dagens dato, siden vi da får nyeste leder på personen (for den gitte virksomheten).