### PR TITLE
Don't send moter from more than two months ago to moteoversikt

### DIFF
--- a/src/main/java/no/nav/syfo/api/ressurser/azuread/MoterInternController.java
+++ b/src/main/java/no/nav/syfo/api/ressurser/azuread/MoterInternController.java
@@ -132,13 +132,13 @@ public class MoterInternController {
 
         List<Mote> moterByVeileder = new ArrayList<>();
         if (!isEmpty(veiledersMoter) && veiledersMoter) {
-            moterByVeileder.addAll(moteService.moterWithMaxTwoMonthOldTidVeileder(getSubjectInternAzure(contextHolder)));
+            moterByVeileder.addAll(moteService.maxTwoMonthOldMoterVeileder(getSubjectInternAzure(contextHolder)));
             moter.addAll(moterByVeileder);
         }
 
         List<Mote> moterByNavEnhet = new ArrayList<>();
         if (!isEmpty(navenhet) && hoererNavEnhetTilBruker(navenhet, getSubjectInternAzure(contextHolder))) {
-            moterByNavEnhet.addAll(moteService.moterWithMaxTwoMonthOldTidEnhet(navenhet));
+            moterByNavEnhet.addAll(moteService.maxTwoMonthOldMoterEnhet(navenhet));
             moter.addAll(moterByNavEnhet);
         }
 

--- a/src/main/java/no/nav/syfo/service/MoteService.java
+++ b/src/main/java/no/nav/syfo/service/MoteService.java
@@ -28,7 +28,7 @@ import static no.nav.syfo.kafka.producer.OversikthendelseType.MOTEPLANLEGGER_ALL
 import static no.nav.syfo.kafka.producer.OversikthendelseType.MOTEPLANLEGGER_ALLE_SVAR_MOTTATT;
 import static no.nav.syfo.repository.model.PFeedHendelse.FeedHendelseType.ALLE_SVAR_MOTTATT;
 import static no.nav.syfo.service.MotedeltakerService.finnAktoerIMote;
-import static no.nav.syfo.util.MoteUtilKt.moterWithTidAfterGivenDate;
+import static no.nav.syfo.util.MoteUtilKt.moterAfterGivenDate;
 import static no.nav.syfo.util.MoterUtil.filtrerBortAlternativerSomAlleredeErLagret;
 import static no.nav.syfo.util.MoterUtil.hentSisteSvartidspunkt;
 
@@ -257,22 +257,22 @@ public class MoteService {
         return moteDAO.findMoterByNavAnsatt(navansatt);
     }
 
-    public List<Mote> moterWithMaxTwoMonthOldTidVeileder(String navansatt) {
+    public List<Mote> maxTwoMonthOldMoterVeileder(String navansatt) {
         List<Mote> allNavAnsattMoter = findMoterByBrukerNavAnsatt(navansatt);
 
         LocalDateTime twoMonthsAgo = LocalDateTime.now().minusMonths(2);
-        return moterWithTidAfterGivenDate(allNavAnsattMoter, twoMonthsAgo);
+        return moterAfterGivenDate(allNavAnsattMoter, twoMonthsAgo);
     }
 
     public List<Mote> findMoterByBrukerNavEnhet(String navenhet) {
         return moteDAO.findMoterByNavEnhet(navenhet);
     }
 
-    public List<Mote> moterWithMaxTwoMonthOldTidEnhet(String navenhet) {
+    public List<Mote> maxTwoMonthOldMoterEnhet(String navenhet) {
         List<Mote> allEnhetMoter = findMoterByBrukerNavEnhet(navenhet);
 
         LocalDateTime twoMonthsAgo = LocalDateTime.now().minusMonths(2);
-        return moterWithTidAfterGivenDate(allEnhetMoter, twoMonthsAgo);
+        return moterAfterGivenDate(allEnhetMoter, twoMonthsAgo);
     }
 
     private void opprettFeedHendelseAvTypen(PFeedHendelse.FeedHendelseType type, Mote Mote, String veilederIdent) {

--- a/src/main/kotlin/no/nav/syfo/util/MoteUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/MoteUtil.kt
@@ -9,6 +9,6 @@ fun newestTidFromMoteAlternativ(mote: Mote): LocalDateTime {
     return alternativWithBiggestTid!!.tid
 }
 
-fun moterWithTidAfterGivenDate(moter: List<Mote>, date: LocalDateTime): List<Mote> {
+fun moterAfterGivenDate(moter: List<Mote>, date: LocalDateTime): List<Mote> {
     return moter.filter { newestTidFromMoteAlternativ(it).isAfter(date) }
 }

--- a/src/test/java/no/nav/syfo/api/ressurser/azuread/MoterInternControllerTest.java
+++ b/src/test/java/no/nav/syfo/api/ressurser/azuread/MoterInternControllerTest.java
@@ -120,7 +120,7 @@ public class MoterInternControllerTest extends AbstractRessursTilgangTest {
         when(aktorregisterConsumer.getFnrForAktorId(new AktorId(AKTOER_ID_2))).thenReturn(FNR_2);
         when(aktorregisterConsumer.getFnrForAktorId(new AktorId(LEDER_AKTORID))).thenReturn(LEDER_FNR);
         when(moteService.findMoterByBrukerNavEnhet(NAV_ENHET)).thenReturn(MoteList);
-        when(moteService.moterWithMaxTwoMonthOldTidEnhet(NAV_ENHET)).thenReturn(MoteList);
+        when(moteService.maxTwoMonthOldMoterEnhet(NAV_ENHET)).thenReturn(MoteList);
     }
 
     @After

--- a/src/test/kotlin/no/nav/syfo/util/MoteUtilTest.kt
+++ b/src/test/kotlin/no/nav/syfo/util/MoteUtilTest.kt
@@ -19,7 +19,7 @@ class MoteUtilTest {
     @Test
     fun `moterWithTidAfterGivenDate Return empty list when empty list is provided`() {
         val emptyMoterList = emptyList<Mote>()
-        val actualMoteList = moterWithTidAfterGivenDate(emptyMoterList, NOW)
+        val actualMoteList = moterAfterGivenDate(emptyMoterList, NOW)
 
         assertThat(actualMoteList.size).isEqualTo(0)
     }
@@ -27,7 +27,7 @@ class MoteUtilTest {
     @Test
     fun `moterWithTidAfterGivenDate Return empty list when all moter is before given date`() {
         val moterWithOldTid = listOf(createMoteWithGivenTid(TEN_DAYS_AGO))
-        val actualMoteList = moterWithTidAfterGivenDate(moterWithOldTid, NOW)
+        val actualMoteList = moterAfterGivenDate(moterWithOldTid, NOW)
 
         assertThat(actualMoteList.size).isEqualTo(0)
     }
@@ -35,7 +35,7 @@ class MoteUtilTest {
     @Test
     fun `moterWithTidAfterGivenDate Return list with one element when one mote is after given date`() {
         val moterWithNewTid = listOf(createMoteWithGivenTid(TEN_DAYS_FROM_NOW))
-        val actualMoteList = moterWithTidAfterGivenDate(moterWithNewTid, NOW)
+        val actualMoteList = moterAfterGivenDate(moterWithNewTid, NOW)
 
         assertThat(actualMoteList.size).isEqualTo(1)
     }
@@ -46,7 +46,7 @@ class MoteUtilTest {
                 createMoteWithGivenTid(TEN_DAYS_FROM_NOW),
                 createMoteWithGivenTid(TEN_DAYS_AGO)
         )
-        val actualMoteList = moterWithTidAfterGivenDate(moterWithMixedTid, NOW)
+        val actualMoteList = moterAfterGivenDate(moterWithMixedTid, NOW)
 
         assertThat(actualMoteList.size).isEqualTo(1)
     }


### PR DESCRIPTION
En del veiledere klager på at de får veldig mange møter i møteoversikten sin,
dette skal gjøre at de kun får møter med ønsket tidspunkt nyere enn for to måneder siden.
Vi bruker alle alternativer som grunnlag for å sjekke tidspunkt, og forholder oss til det tidspunktet som er lengst frem i tid, uavhengig av valgte/bekreftede alternativer.
To måneder er satt som grense av fag, og antas å gi en god balanse mellom historikk og oversiktlighet.