### PR TITLE
Use moteUUID as Kafka message key

### DIFF
--- a/src/main/java/no/nav/syfo/kafka/producer/OversikthendelseProducer.java
+++ b/src/main/java/no/nav/syfo/kafka/producer/OversikthendelseProducer.java
@@ -21,11 +21,11 @@ public class OversikthendelseProducer {
         this.kafkaTemplate = kafkaTemplate;
     }
 
-    public void sendOversikthendelse(KOversikthendelse kOversikthendelse) {
+    public void sendOversikthendelse(String key, KOversikthendelse kOversikthendelse) {
         try {
             kafkaTemplate.send(
                     OVERSIKTHENDELSE_TOPIC,
-                    randomUUID().toString(),
+                    key,
                     kOversikthendelse
             ).get();
             log.info("Legger oversikthendelse med id {} på kø for enhet {}", kOversikthendelse.getHendelseId(), kOversikthendelse.getEnhetId());

--- a/src/main/java/no/nav/syfo/service/OversikthendelseService.java
+++ b/src/main/java/no/nav/syfo/service/OversikthendelseService.java
@@ -40,6 +40,6 @@ public class OversikthendelseService {
                 .tidspunkt(now()
                 ).build();
 
-        oversikthendelseProducer.sendOversikthendelse(kOversikthendelse);
+        oversikthendelseProducer.sendOversikthendelse(mote.uuid, kOversikthendelse);
     }
 }

--- a/src/test/kotlin/no/nav/syfo/kafka/producer/OversikthendelseProducerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kafka/producer/OversikthendelseProducerTest.kt
@@ -11,6 +11,7 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.support.SendResult
 import org.springframework.util.concurrent.ListenableFuture
 import java.time.LocalDateTime
+import java.util.*
 
 @RunWith(MockitoJUnitRunner::class)
 class OversikthendelseProducerTest {
@@ -29,7 +30,7 @@ class OversikthendelseProducerTest {
             .enhetId(NAV_ENHET)
             .tidspunkt(LocalDateTime.now())
             .build()
-        oversikthendelseProducer.sendOversikthendelse(kOversikthendelse)
+        oversikthendelseProducer.sendOversikthendelse(UUID.randomUUID().toString(), kOversikthendelse)
         Mockito.verify(kafkaTemplate).send(ArgumentMatchers.eq(OversikthendelseProducer.OVERSIKTHENDELSE_TOPIC), ArgumentMatchers.anyString(), ArgumentMatchers.same(kOversikthendelse))
     }
 
@@ -42,7 +43,7 @@ class OversikthendelseProducerTest {
             .enhetId(NAV_ENHET)
             .tidspunkt(LocalDateTime.now())
             .build()
-        oversikthendelseProducer.sendOversikthendelse(kOversikthendelse)
+        oversikthendelseProducer.sendOversikthendelse(UUID.randomUUID().toString(), kOversikthendelse)
         Mockito.verify(kafkaTemplate).send(ArgumentMatchers.eq(OversikthendelseProducer.OVERSIKTHENDELSE_TOPIC), ArgumentMatchers.anyString(), ArgumentMatchers.same(kOversikthendelse))
     }
 }


### PR DESCRIPTION
Use moteUUID as key for produced messages to both topic for Oversikthendelse. This will ensure that messages with the same key will be sent to the same partition and hence it can be guaranteed that messages with the same key is processed in order.