### PR TITLE
Add PathVariable varsle to endpoint BekreftMote

### DIFF
--- a/src/main/java/no/nav/syfo/service/MoteService.java
+++ b/src/main/java/no/nav/syfo/service/MoteService.java
@@ -116,7 +116,12 @@ public class MoteService {
     }
 
     @Transactional
-    public void bekreftMote(String moteUuid, Long tidOgStedId, String veilederIdent) {
+    public void bekreftMote(
+            String moteUuid,
+            Long tidOgStedId,
+            Boolean varsle,
+            String veilederIdent
+        ) {
         Mote mote = moteDAO.findMoteByUUID(moteUuid);
 
         metric.reportAntallDagerSiden(mote.opprettetTidspunkt, "antallDagerForSvar");
@@ -128,8 +133,11 @@ public class MoteService {
         hendelseService.moteStatusEndret(mote.status(BEKREFTET), veilederIdent);
 
         mqStoppRevarslingService.stoppReVarsel(finnAktoerIMote(mote).uuid);
-        arbeidsgiverVarselService.sendVarsel(Varseltype.BEKREFTET, mote, false, veilederIdent);
-        sykmeldtVarselService.sendVarsel(Varseltype.BEKREFTET, mote);
+
+        if (varsle) {
+            arbeidsgiverVarselService.sendVarsel(Varseltype.BEKREFTET, mote, false, veilederIdent);
+            sykmeldtVarselService.sendVarsel(Varseltype.BEKREFTET, mote);
+        }
         if (feedService.skalOppretteFeedHendelse(mote, PFeedHendelse.FeedHendelseType.BEKREFTET)) {
             opprettFeedHendelseAvTypen(PFeedHendelse.FeedHendelseType.BEKREFTET, mote, veilederIdent);
         }

--- a/src/main/kotlin/no/nav/syfo/controller/internad/MoteActionsController.kt
+++ b/src/main/kotlin/no/nav/syfo/controller/internad/MoteActionsController.kt
@@ -42,12 +42,14 @@ constructor(
     @PostMapping(consumes = [APPLICATION_JSON_VALUE], produces = [APPLICATION_JSON_VALUE])
     @RequestMapping(value = ["/bekreft"])
     fun bekreft(
-            @PathVariable("moteUuid") moteUuid: String,
-            @RequestParam(value = "valgtAlternativId") tidOgStedId: Long
+        @PathVariable("moteUuid") moteUuid: String,
+        @RequestParam(value = "valgtAlternativId") tidOgStedId: Long,
+        @RequestParam(value = "varsle") varsle: Boolean?
     ) {
         moteService.bekreftMote(
                 moteUuid,
                 tidOgStedId,
+                varsle ?: true,
                 getSubjectInternAzure(contextHolder)
         )
 

--- a/src/test/kotlin/no/nav/syfo/controller/internad/MoteActionsControllerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/controller/internad/MoteActionsControllerTest.kt
@@ -65,16 +65,26 @@ class MoteActionsControllerTest {
         val uuid = UUID.randomUUID()
         val alternativId = 1L
 
-        moteActionsController.bekreft(uuid.toString(), alternativId)
+        moteActionsController.bekreft(uuid.toString(), alternativId, null)
 
-        verify(moteService).bekreftMote(uuid.toString(), alternativId, VEILEDER_ID)
+        verify(moteService).bekreftMote(uuid.toString(), alternativId, true, VEILEDER_ID)
+    }
+
+    @Test
+    fun bekreftDialogmoteVarsleFalseHasAccess() {
+        val uuid = UUID.randomUUID()
+        val alternativId = 1L
+
+        moteActionsController.bekreft(uuid.toString(), alternativId, false)
+
+        verify(moteService).bekreftMote(uuid.toString(), alternativId, false, VEILEDER_ID)
     }
 
     @Test(expected = RuntimeException::class)
     fun bekreftDialogmoteServerError() {
         loggUtAlle(oidcRequestContextHolder)
 
-        moteActionsController.bekreft(UUID.randomUUID().toString(), 1L)
+        moteActionsController.bekreft(UUID.randomUUID().toString(), 1L, null)
     }
 
     @Test


### PR DESCRIPTION
Only send notification to Arbeidstaker and Arbeidsgiver if request to endpoint BekreftMote has enabled notifications(varsle). Default for varsle=true. This parameter is added to support two types of BekreftMote: One where new Moteinkalling in Isdialogmote is used and one where it is used.