### PR TITLE
Fix bug with MOTEPLANLEGGER_ALLE_SVAR_BEHANDLET

### DIFF
--- a/src/main/java/no/nav/syfo/service/MoteService.java
+++ b/src/main/java/no/nav/syfo/service/MoteService.java
@@ -183,7 +183,7 @@ public class MoteService {
         moteDAO.oppdaterMoteEier(moteUuid, mottakerUserId);
     }
 
-    private boolean harDeltakerSvartTidligereEnnNyesteOpprettet(Motedeltaker motedeltaker, LocalDateTime nyesteAlternativOpprettetTidspunkt) {
+    private boolean harDeltakerIkkeSvartEllerSvartTidligereEnnNyesteOpprettet(Motedeltaker motedeltaker, LocalDateTime nyesteAlternativOpprettetTidspunkt) {
         return Optional.ofNullable(motedeltaker.svartTidspunkt)
                 .map(svartTidspunkt -> svartTidspunkt.isBefore(nyesteAlternativOpprettetTidspunkt))
                 .orElse(true);
@@ -196,16 +196,7 @@ public class MoteService {
 
         return Mote.motedeltakere.stream()
                 .filter(erIkkeReservertSykmeldt(skalSykmeldtHaVarsler))
-                .noneMatch(deltaker -> harDeltakerSvartTidligereEnnNyesteOpprettet(deltaker, nyesteAlternativOpprettetTidspunkt) ||
-                        sisteSvarErIkkeReservertBruk(Mote, skalSykmeldtHaVarsler));
-    }
-
-    private boolean sisteSvarErIkkeReservertBruk(Mote Mote, boolean skalSykmeldtHaVarsler) {
-        return !skalSykmeldtHaVarsler &&
-                Mote.motedeltakere.stream()
-                        .filter(motedeltaker -> motedeltaker.svartTidspunkt != null)
-                        .sorted((o1, o2) -> o2.svartTidspunkt.compareTo(o1.svartTidspunkt))
-                        .findFirst().get().motedeltakertype.equals("Bruker");
+                .noneMatch(deltaker -> harDeltakerIkkeSvartEllerSvartTidligereEnnNyesteOpprettet(deltaker, nyesteAlternativOpprettetTidspunkt));
     }
 
     private Predicate<Motedeltaker> erIkkeReservertSykmeldt(boolean skalSykmeldtHaVarsler) {


### PR DESCRIPTION
Fix bug related to MOTEPLANLEGGER_ALLE_SVAR_BEHANDLET. The bug occurs in the following scenario: Arbeidstaker first has KanVarsles=true when Mote is created. Then participants answer where Arbeidstaker is the last one to answer. Then the state of Arbeidstaker change to KanVarsles=false, e.g. if the Arbeidstaker reserves himself from digital communication. Lastly, a Veileder marks the Mote as done and the created Syfooversikt-task is never marked as done. This fix should solve this issue.