### PR TITLE
Ignore unknown properties when mapping LeaderPod

### DIFF
--- a/src/main/kotlin/no/nav/syfo/batch/leaderelection/LeaderElectionService.kt
+++ b/src/main/kotlin/no/nav/syfo/batch/leaderelection/LeaderElectionService.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.batch.leaderelection
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.syfo.metric.Metric
 import org.slf4j.LoggerFactory
@@ -14,12 +15,12 @@ import javax.inject.Inject
 class LeaderElectionService @Inject constructor(
     private val metric: Metric,
     private val restTemplate: RestTemplate,
-    @Value("\${elector.path}") private val electorpath: String
+    @Value("\${elector.path}") private val electorpath: String,
 ) {
     val isLeader: Boolean
         get() {
             metric.countEvent("isLeader_kalt")
-            val objectMapper = ObjectMapper()
+            val objectMapper = ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             val url = "http://$electorpath"
             val response = restTemplate.getForObject(url, String::class.java)
             return try {


### PR DESCRIPTION
Fikser feil ved kjøring av scheduled task pga ny ukjent, property på LeaderPod

```
om.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "last_update" (class no.nav.syfo.batch.leaderelection.LeaderPod), not marked as ignorable (one known property: "name"])
at [Source: (String)"{"name":"syfomoteadmin-596b9689b7-p79cw","last_update":"2022-01-28T06:59:38Z"}"; line: 1, column: 57] (through reference chain: no.nav.syfo.batch.leaderelection.LeaderPod["last_update"])
at com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.from(UnrecognizedPropertyException.java:61)
```